### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
     "async": "^1.4.2",
     "lodash": "^3.10.1",
     "macaddress": "^0.2.8",
-    "node-uuid": "^1.4.3",
     "seneca-auth": "0.4.0",
     "seneca-crypt": "~0.0.1",
-    "seneca-user": "0.2.10"
+    "seneca-user": "0.2.10",
+    "uuid": "^3.0.0"
   },
   "repository": {
     "type": "git",

--- a/protocol/base/identify.js
+++ b/protocol/base/identify.js
@@ -1,7 +1,5 @@
 "use strict"
 
-var uuid = require( 'node-uuid' )
-
 module.exports = function( options ) {
   var seneca = this;
   var protocol_version = seneca.export( 'constants/protocol_version' )

--- a/protocol/v1/authorize.js
+++ b/protocol/v1/authorize.js
@@ -1,17 +1,17 @@
 "use strict"
 
-var uuid = require( 'node-uuid' )
+var uuid = require( 'uuid' )
 
 module.exports = function( options ) {
   var seneca = this;
   var name = 'protocol_v1'
 
   // this should eventually be moved to another
-  var token = uuid()
+  var token = uuid.v4()
 
 
   function create_auth_token( args, done ) {
-    token = uuid()
+    token = uuid.v4()
 
     done( null, {token: token} )
   }


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.